### PR TITLE
Implement support for processing payments of orders containing books

### DIFF
--- a/src/shipping_labels.py
+++ b/src/shipping_labels.py
@@ -1,7 +1,11 @@
 class ShippingLabel:
-    def __init__(self, shipping_address, customer):
+    def __init__(self, shipping_address, customer, is_tax_exempt=False):
         self.customer = customer
         self.shipping_address = shipping_address
+        self.is_tax_exempt = is_tax_exempt
+
+    def __repr__(self):
+        return str(f'ShippingLabel <TaxExempt: {self.is_tax_exempt}>')
 
     def __eq__(self, other):
         return isinstance(other, ShippingLabel) and self.__dict__ == other.__dict__

--- a/test/test_book_order_payments.py
+++ b/test/test_book_order_payments.py
@@ -1,0 +1,62 @@
+import unittest
+
+from src import shipping_labels
+from src.bootstrap import Address
+from src.bootstrap import CreditCard
+from src.bootstrap import Customer
+from src.bootstrap import Item
+from src.bootstrap import ItemType
+from src.bootstrap import Order
+from src.bootstrap import OrderItems
+from src.bootstrap import Payment
+from src.shipping_labels import ShippingLabel
+
+
+class TestBookOrderPayments(unittest.TestCase):
+    def test_processing_the_payment_for_an_order_containing_multiple_books(self):
+        lord_of_the_cubes = Item(
+            type=ItemType.BOOK,
+            price=10.0,
+            name='Lord of the Cubes'
+        )
+        midnight = Item(
+            type=ItemType.BOOK,
+            price=5.0,
+            name='Midnight'
+        )
+        customer = Customer(
+            name='John',
+            surname='Smith',
+            email_address='john.smith@gogol.eus'
+        )
+        address = Address(
+            zip_code='46001',
+            street='C/ xxx'
+        )
+        order = Order(
+            customer=customer,
+            shipping_address=address,
+            billing_address=address,
+            items=[
+                OrderItems(item=lord_of_the_cubes, quantity=2),
+                OrderItems(item=midnight, quantity=2),
+            ]
+        )
+        payment = Payment(
+            payment_method=CreditCard.fetch_by_hased('VISA-xxx'),
+            order=order
+        )
+
+        payment.pay()
+
+        assert payment.is_paid
+        assert payment.order.subtotal == 30.0
+        assert payment.order.items[0].item == lord_of_the_cubes
+        assert payment.order.items[1].item == midnight
+
+        latest_shipping_label = shipping_labels.latest()
+        assert latest_shipping_label == ShippingLabel(
+            shipping_address=address,
+            customer=customer,
+            is_tax_exempt=True
+        )

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -97,7 +97,7 @@ class TestOrder(unittest.TestCase):
         assert order.contains_physical_items is True
 
     def test_order_reports_it_contains_a_digital_subscription_item(self):
-        screwdriver = Item(
+        gogol_music = Item(
             type=ItemType.SUBSCRIPTION,
             price=10.0,
             name='Gogol Music'
@@ -107,8 +107,25 @@ class TestOrder(unittest.TestCase):
             shipping_address=self.address,
             billing_address=self.address,
             items=[
-                OrderItems(item=screwdriver, quantity=3)
+                OrderItems(item=gogol_music, quantity=3)
             ]
         )
 
         assert order.contains_subscriptions is True
+
+    def test_order_reports_it_contains_a_book(self):
+        book = Item(
+            type=ItemType.BOOK,
+            price=10.0,
+            name='Python for Dummies'
+        )
+        order = Order(
+            customer=self.customer,
+            shipping_address=self.address,
+            billing_address=self.address,
+            items=[
+                OrderItems(item=book, quantity=3)
+            ]
+        )
+
+        assert order.contains_books is True

--- a/test/test_physical_item_order_payments.py
+++ b/test/test_physical_item_order_payments.py
@@ -14,32 +14,13 @@ from src.shipping_labels import ShippingLabel
 
 class TestPhysicalItemOrderPayments(unittest.TestCase):
     def test_processing_the_payment_for_an_order_containing_multiple_physical_items(self):
-        screwdriver = Item(
-            type=ItemType.PHYSICAL,
-            price=10.0,
-            name='Screwdriver'
-        )
-        hammer = Item(
-            type=ItemType.PHYSICAL,
-            price=5.0,
-            name='Hammer'
-        )
-        customer = Customer(
-            name='John',
-            surname='Smith',
-            email_address='john.smith@gogol.eus'
-        )
-        address = Address(
-            zip_code='46001',
-            street='C/ xxx'
-        )
         order = Order(
-            customer=customer,
-            shipping_address=address,
-            billing_address=address,
+            customer=self.customer,
+            shipping_address=self.address,
+            billing_address=self.address,
             items=[
-                OrderItems(item=screwdriver, quantity=2),
-                OrderItems(item=hammer, quantity=2),
+                OrderItems(item=self.screwdriver, quantity=2),
+                OrderItems(item=self.hammer, quantity=2),
             ]
         )
         payment = Payment(
@@ -51,11 +32,32 @@ class TestPhysicalItemOrderPayments(unittest.TestCase):
 
         assert payment.is_paid
         assert payment.order.subtotal == 30.0
-        assert payment.order.items[0].item == screwdriver
-        assert payment.order.items[1].item == hammer
+        assert payment.order.items[0].item == self.screwdriver
+        assert payment.order.items[1].item == self.hammer
 
         latest_shipping_label = shipping_labels.latest()
         assert latest_shipping_label == ShippingLabel(
-            shipping_address=address,
-            customer=customer
+            shipping_address=self.address,
+            customer=self.customer
+        )
+
+    def setUp(self):
+        self.screwdriver = Item(
+            type=ItemType.PHYSICAL,
+            price=10.0,
+            name='Screwdriver'
+        )
+        self.hammer = Item(
+            type=ItemType.PHYSICAL,
+            price=5.0,
+            name='Hammer'
+        )
+        self.customer = Customer(
+            name='John',
+            surname='Smith',
+            email_address='john.smith@gogol.eus'
+        )
+        self.address = Address(
+            zip_code='46001',
+            street='C/ xxx'
         )

--- a/test/test_subscription_payments.py
+++ b/test/test_subscription_payments.py
@@ -16,26 +16,12 @@ from src.email_sender import EmailTemplate
 
 class TestSubscriptionPayments(unittest.TestCase):
     def test_processing_the_payment_for_an_order_containing_multiple_physical_items(self):
-        gogol_music = Item(
-            type=ItemType.SUBSCRIPTION,
-            price=5.0,
-            name='Gogol Music'
-        )
-        customer = Customer(
-            name='John',
-            surname='Smith',
-            email_address='john.smith@gogol.eus'
-        )
-        address = Address(
-            zip_code='46001',
-            street='C/ xxx'
-        )
         order = Order(
-            customer=customer,
-            shipping_address=address,
-            billing_address=address,
+            customer=self.customer,
+            shipping_address=self.address,
+            billing_address=self.address,
             items=[
-                OrderItems(item=gogol_music, quantity=1)
+                OrderItems(item=self.gogol_music, quantity=1)
             ]
         )
         payment = Payment(
@@ -47,11 +33,27 @@ class TestSubscriptionPayments(unittest.TestCase):
 
         assert payment.is_paid
         assert payment.order.subtotal == 5.0
-        assert payment.order.items[0].item == gogol_music
+        assert payment.order.items[0].item == self.gogol_music
 
         assert email_sender.latest() == Email.from_template(
             template=EmailTemplate.SUBSCRIPTION_ACTIVATION,
             order=order
         )
 
-        assert gogol_music in subscription_service.activated_subscriptions_for_customer(customer)
+        assert self.gogol_music in subscription_service.activated_subscriptions_for_customer(self.customer)
+
+    def setUp(self):
+        self.gogol_music = Item(
+            type=ItemType.SUBSCRIPTION,
+            price=5.0,
+            name='Gogol Music'
+        )
+        self.customer = Customer(
+            name='John',
+            surname='Smith',
+            email_address='john.smith@gogol.eus'
+        )
+        self.address = Address(
+            zip_code='46001',
+            street='C/ xxx'
+        )


### PR DESCRIPTION
Closes #4 

Summary
=======

In this PR support for processing payments of orders containing books has been implemented, as well as combined with other item types.

Some unit tests have been refactored to be more readable. 