### PR TITLE
Support processing payments of orders containing digital media

### DIFF
--- a/src/email_sender.py
+++ b/src/email_sender.py
@@ -3,6 +3,8 @@ from enum import Enum
 
 class EmailTemplate(Enum):
     SUBSCRIPTION_ACTIVATION = 'subscription_activation'
+    DIGITAL_MEDIA_ACCESS = 'digital_media_access'
+    DISCOUNT_VOUCHER = 'digital_media_access'
 
 
 class Email:
@@ -18,12 +20,12 @@ class Email:
         return isinstance(other, Email) and other.__dict__ ==  self.__dict__
 
 
-emails = []
+sent_emails = []
 
 
 def send(email):
-    emails.append(email)
+    sent_emails.append(email)
 
 
 def latest():
-    return emails[-1]
+    return sent_emails[-1]

--- a/test/test_book_order_payments.py
+++ b/test/test_book_order_payments.py
@@ -14,32 +14,13 @@ from src.shipping_labels import ShippingLabel
 
 class TestBookOrderPayments(unittest.TestCase):
     def test_processing_the_payment_for_an_order_containing_multiple_books(self):
-        lord_of_the_cubes = Item(
-            type=ItemType.BOOK,
-            price=10.0,
-            name='Lord of the Cubes'
-        )
-        midnight = Item(
-            type=ItemType.BOOK,
-            price=5.0,
-            name='Midnight'
-        )
-        customer = Customer(
-            name='John',
-            surname='Smith',
-            email_address='john.smith@gogol.eus'
-        )
-        address = Address(
-            zip_code='46001',
-            street='C/ xxx'
-        )
         order = Order(
-            customer=customer,
-            shipping_address=address,
-            billing_address=address,
+            customer=self.customer,
+            shipping_address=self.address,
+            billing_address=self.address,
             items=[
-                OrderItems(item=lord_of_the_cubes, quantity=2),
-                OrderItems(item=midnight, quantity=2),
+                OrderItems(item=self.lord_of_the_cubes, quantity=2),
+                OrderItems(item=self.midnight, quantity=2),
             ]
         )
         payment = Payment(
@@ -51,12 +32,33 @@ class TestBookOrderPayments(unittest.TestCase):
 
         assert payment.is_paid
         assert payment.order.subtotal == 30.0
-        assert payment.order.items[0].item == lord_of_the_cubes
-        assert payment.order.items[1].item == midnight
+        assert payment.order.items[0].item == self.lord_of_the_cubes
+        assert payment.order.items[1].item == self.midnight
 
         latest_shipping_label = shipping_labels.latest()
         assert latest_shipping_label == ShippingLabel(
-            shipping_address=address,
-            customer=customer,
+            shipping_address=self.address,
+            customer=self.customer,
             is_tax_exempt=True
+        )
+
+    def setUp(self):
+        self.lord_of_the_cubes = Item(
+            type=ItemType.BOOK,
+            price=10.0,
+            name='Lord of the Cubes'
+        )
+        self.midnight = Item(
+            type=ItemType.BOOK,
+            price=5.0,
+            name='Midnight'
+        )
+        self.customer = Customer(
+            name='John',
+            surname='Smith',
+            email_address='john.smith@gogol.eus'
+        )
+        self.address = Address(
+            zip_code='46001',
+            street='C/ xxx'
         )

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -129,3 +129,20 @@ class TestOrder(unittest.TestCase):
         )
 
         assert order.contains_books is True
+
+    def test_order_reports_it_contains_a_digital_item(self):
+        song = Item(
+            type=ItemType.DIGITAL_MEDIA,
+            price=10.0,
+            name='Imagine'
+        )
+        order = Order(
+            customer=self.customer,
+            shipping_address=self.address,
+            billing_address=self.address,
+            items=[
+                OrderItems(item=song, quantity=3)
+            ]
+        )
+
+        assert order.contains_digital_media is True


### PR DESCRIPTION
Closes #5 

Summary
=======

This PR implements the support to process payments of orders containing digital media, either alone or combined with other types of item. Some other unit tests have also been refactored to improve readability.